### PR TITLE
simplify env.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,9 @@ WORKDIR /usr/share/nginx/html
 COPY ./env.sh .
 COPY .env .
 
-# Add bash
-RUN apk add --no-cache bash
-
 # Run script which initializes env vars to fs
 RUN chmod +x env.sh
 # RUN ./env.sh
 
 # Start Nginx server
-CMD ["/bin/bash", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]
+CMD ["/bin/sh", "-c", "/usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""]

--- a/README.md
+++ b/README.md
@@ -95,36 +95,11 @@ puts environment variable values as object which is assigned as property of
 `window` object.
 
 ```
-#!/bin/bash
-
-# Recreate config file
-rm -rf ./env-config.js
-touch ./env-config.js
-
-# Add assignment
-echo "window._env_ = {" >> ./env-config.js
-
-# Read each line in .env file
-# Each line represents key=value pairs
-while read -r line || [[ -n "$line" ]];
-do
-  # Split env variables by character `=`
-  if printf '%s\n' "$line" | grep -q -e '='; then
-    varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
-    varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
-  fi
-
-  # Read value of current variable if exists as Environment variable
-  value=$(printf '%s\n' "${!varname}")
-  # Otherwise use value from .env file
-  [[ -z $value ]] && value=${varvalue}
-
-  # Append configuration property to JS file
-  echo "  $varname: \"$value\"," >> ./env-config.js
-done < .env
-
+#!/bin/sh
+# line endings must be \n, not \r\n !
+echo "window._env_ = {" > ./env-config.js
+awk -F '=' '{ print $1 ": \"" (ENVIRON[$1] ? ENVIRON[$1] : $2) "\"," }' ./.env >> ./env-config.js
 echo "}" >> ./env-config.js
-view raw
 ```
 
 > env.sh
@@ -290,9 +265,6 @@ EXPOSE 80
 WORKDIR /usr/share/nginx/html
 COPY ./env.sh .
 COPY .env .
-
-# Add bash
-RUN apk add --no-cache bash
 
 # Make our shell script executable
 RUN chmod +x env.sh

--- a/env.sh
+++ b/env.sh
@@ -1,29 +1,5 @@
-#!/bin/bash
-
-# Recreate config file
-rm -rf ./env-config.js
-touch ./env-config.js
-
-# Add assignment 
-echo "window._env_ = {" >> ./env-config.js
-
-# Read each line in .env file
-# Each line represents key=value pairs
-while read -r line || [[ -n "$line" ]];
-do
-  # Split env variables by character `=`
-  if printf '%s\n' "$line" | grep -q -e '='; then
-    varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
-    varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
-  fi
-
-  # Read value of current variable if exists as Environment variable
-  value=$(printf '%s\n' "${!varname}")
-  # Otherwise use value from .env file
-  [[ -z $value ]] && value=${varvalue}
-  
-  # Append configuration property to JS file
-  echo "  $varname: \"$value\"," >> ./env-config.js
-done < .env
-
+#!/bin/sh
+# line endings must be \n, not \r\n !
+echo "window._env_ = {" > ./env-config.js
+awk -F '=' '{ print $1 ": \"" (ENVIRON[$1] ? ENVIRON[$1] : $2) "\"," }' ./.env >> ./env-config.js
 echo "}" >> ./env-config.js


### PR DESCRIPTION
remove dependency to `bash` by reducing env.sh to 1 line of `awk` script
`awk` is readily included in `nginx:alpine`

I found your blog post immensely helpful. But the `env.sh` took me a while to read. May I propose to condense the main loop to 1 line of `awk` ?